### PR TITLE
ensure profileMap interpretation exists

### DIFF
--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -683,7 +683,7 @@ class PipelineWorker : public Nan::AsyncWorker {
           const_cast<char*>(baton->iccTransformPath.data()),
           VImage::option()
           ->set("intent", VIPS_INTENT_PERCEPTUAL)
-          ->set("input_profile", const_cast<char*>(profileMap[image.interpretation()].data())));
+          ->set("input_profile", const_cast<char*>(profileMap[VIPS_INTERPRETATION_sRGB].data())));
       }
 
       // Override EXIF Orientation tag


### PR DESCRIPTION
This isn't perfect as we're not necessarily mapping from sRGB but works as a PoC